### PR TITLE
Allows changes to users with gmail addresses

### DIFF
--- a/lib/user_validator.rb
+++ b/lib/user_validator.rb
@@ -7,7 +7,7 @@ class UserValidator < ActiveModel::Validator
 
     record.errors.add(:email, "is taken. We only allow one subdomain email address") if subdomain_duplicate(record)
 
-    record.errors.add(:email, "is taken. We only allow one gmail dot address") if gmail_duplicate(record.email)
+    record.errors.add(:email, "is taken. We only allow one gmail dot address") if gmail_duplicate(record)
   end
 
   def subdomain_duplicate(record)
@@ -29,10 +29,11 @@ class UserValidator < ActiveModel::Validator
     email_address.split('@').last
   end
 
-  def gmail_duplicate(email_address)
+  def gmail_duplicate(record)
+    email_address = record.email
     username, domain = email_address.split('@')
 
-    return false unless domain == GMAIL_DOMAIN
+    return false unless (domain == GMAIL_DOMAIN && record.new_record?)
 
     gmail_users = User.where('email ~* ?', GMAIL_DOMAIN)
     gmail_usernames = gmail_users.pluck(:email).map {|e| e.split('@').first }.map {|r| r.gsub('.','') }.uniq

--- a/lib/user_validator.rb
+++ b/lib/user_validator.rb
@@ -7,7 +7,7 @@ class UserValidator < ActiveModel::Validator
 
     record.errors.add(:email, "is taken. We only allow one subdomain email address") if subdomain_duplicate(record)
 
-    record.errors.add(:email, "is taken. We only allow one gmail dot address") if gmail_duplicate(record)
+    record.errors.add(:email, "is taken. We only allow one gmail dot address") if gmail_duplicate(record.email)
   end
 
   def subdomain_duplicate(record)
@@ -29,13 +29,12 @@ class UserValidator < ActiveModel::Validator
     email_address.split('@').last
   end
 
-  def gmail_duplicate(record)
-    email_address = record.email
+  def gmail_duplicate(email_address)
     username, domain = email_address.split('@')
 
-    return false unless (domain == GMAIL_DOMAIN && record.new_record?)
+    return false unless domain == GMAIL_DOMAIN
 
-    gmail_users = User.where('email ~* ?', GMAIL_DOMAIN)
+    gmail_users = User.where('email ~* ?', GMAIL_DOMAIN).where.not(email: email_address)
     gmail_usernames = gmail_users.pluck(:email).map {|e| e.split('@').first }.map {|r| r.gsub('.','') }.uniq
 
     gmail_usernames.include?(username.gsub('.',''))

--- a/test/lib/user_validator_test.rb
+++ b/test/lib/user_validator_test.rb
@@ -40,6 +40,13 @@ class UserValidatorTest < ActionMailer::TestCase
     assert(user.valid?)
   end
 
+  test 'lets us make changes to users with gmail addresses' do
+    user = users(:gmail)
+    user.gets_daily_dharma = false
+
+    assert(user.save)
+  end
+
   test 'fails if email address not present' do
     user = User.new
 


### PR DESCRIPTION
The validator was checking the record against all User records, including the one being checked if it was already persisted, to see if there was another record with a "matching" gmail address. This check always came back true thanks to a == a.